### PR TITLE
Enables dotall mode

### DIFF
--- a/main/java/io/github/azagniotov/stubby4j/stubs/RegexParser.java
+++ b/main/java/io/github/azagniotov/stubby4j/stubs/RegexParser.java
@@ -34,7 +34,7 @@ enum RegexParser {
             quote("?")));
 
     void compilePatternAndCache(final String value) {
-        compilePatternAndCache(value, Pattern.MULTILINE);
+        compilePatternAndCache(value, Pattern.MULTILINE | Pattern.DOTALL);
     }
 
     private void compilePatternAndCache(final String value, final int flags) {


### PR DESCRIPTION
with this flag a regex can find a string in a string with newlines (e.g. json payload)